### PR TITLE
Tighter animations

### DIFF
--- a/src/components/animations/fade-into-view.tsx
+++ b/src/components/animations/fade-into-view.tsx
@@ -10,7 +10,7 @@ interface FadeIntoViewProps {
 }
 
 const FadeIntoView = ({ children, className, delay }: FadeIntoViewProps) => (
-  <VisibilitySensor>
+  <VisibilitySensor partialVisibility minTopValue={100}>
     {({ isVisible }) => (
       <Spring
         from={{ opacity: 0 }}


### PR DESCRIPTION
This will make sure that on mobile, large content will also fade in if it doesn't fit on the screen, by checking if the content is at least partially in view.