### PR TITLE
Add BannerNotification content type

### DIFF
--- a/src/components/page/Banner.tsx
+++ b/src/components/page/Banner.tsx
@@ -1,0 +1,19 @@
+import { BannerNotificationEntry } from '../../types/banner'
+
+interface Props {
+  banner?: BannerNotificationEntry
+}
+
+const Banner = ({ banner }: Props): JSX.Element => {
+  if (!banner || !banner.fields.isEnabled) return null
+
+  return (
+    <section className="relative w-full px-8 text-gray-800 bg-[#00a7d3]">
+      <div className="container flex flex-col flex-wrap items-center justify-between py-5 mx-auto max-w-7xl">
+        {banner.fields.message}
+      </div>
+    </section>
+  )
+}
+
+export default Banner

--- a/src/components/page/Layout.tsx
+++ b/src/components/page/Layout.tsx
@@ -1,13 +1,17 @@
 import NavBar from './navbar/NavBar'
+import Banner from './Banner'
+import { BannerNotificationEntry } from '../../types/banner'
 
 interface Props {
   children: JSX.Element
   menu?: Record<string, any>[]
+  banner?: BannerNotificationEntry
 }
 
-const Layout = ({ children, menu }: Props): JSX.Element => {
+const Layout = ({ children, menu, banner }: Props): JSX.Element => {
   return (
     <div className="font-serif">
+      <Banner banner={banner} />
       <NavBar menu={menu} />
       <main>{children}</main>
     </div>

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -3,19 +3,21 @@ import LoadingPage from '../loading/LoadingPage'
 import { PageEntry } from '../../types/page'
 import Section from '../section/Section'
 import { MenuProps } from '../../types/menu'
+import { BannerNotificationEntry } from '../../types/banner'
 
 interface Props {
   page: PageEntry
   menu: MenuProps
+  banner?: BannerNotificationEntry
 }
 
-const Page = ({ page, menu }: Props): JSX.Element => {
+const Page = ({ page, menu, banner }: Props): JSX.Element => {
   if (!page) return <LoadingPage />
 
   const { sections } = page.fields
 
   return (
-    <Layout menu={menu}>
+    <Layout menu={menu} banner={banner}>
       {page ? (
         <>
           {sections?.map((section, index) => {

--- a/src/components/section/ProfileCardSection/ProfileCardSection.tsx
+++ b/src/components/section/ProfileCardSection/ProfileCardSection.tsx
@@ -9,6 +9,7 @@ import GetInTouchButton from './fields/GetInTouchButton'
 import LinkedInIcon from './social/LinkedInIcon'
 import { ProfileSectionEntry } from '../../../types/section'
 import FadeIntoView from '../../animations/fade-into-view'
+import cx from 'classnames'
 
 interface Props {
   section: ProfileSectionEntry
@@ -19,6 +20,7 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
     title,
     slug,
     photo,
+    photoShouldBeOnTheLeft,
     vocation,
     location,
     shortDescription,
@@ -33,6 +35,15 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
 
   const photoUrl = `https:${photo.fields.file.url}`
 
+  const Photo = () => (
+    <div className="w-full lg:w-2/5">
+      <img
+        className="rounded-none lg:rounded-lg shadow-2xl hidden lg:block"
+        src={photoUrl}
+      />
+    </div>
+  )
+
   return (
     <div
       id={slug}
@@ -44,7 +55,19 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
       }}
     >
       <div className="max-w-3xl flex items-center h-auto flex-wrap mx-auto my-12 lg:my-0">
-        <div className="w-full lg:w-3/5 rounded-lg lg:rounded-l-lg lg:rounded-r-none shadow-2xl bg-white opacity-75 mx-6 lg:mx-0">
+        {photoShouldBeOnTheLeft && <Photo />}
+        <div
+          className={cx(
+            'w-full lg:w-3/5 shadow-2xl bg-white opacity-75 mx-6 lg:mx-0',
+            {
+              'rounded-lg': true,
+              'lg:rounded-l-lg': !photoShouldBeOnTheLeft,
+              'lg:rounded-r-none': !photoShouldBeOnTheLeft,
+              'lg:rounded-r-lg': photoShouldBeOnTheLeft,
+              'lg:rounded-l-none': photoShouldBeOnTheLeft,
+            }
+          )}
+        >
           <div className="p-4 lg:p-12 text-center lg:text-left">
             <div
               className="block lg:hidden rounded-full shadow-xl mx-auto -mt-16 h-48 w-48 bg-cover bg-top"
@@ -87,12 +110,7 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
           </div>
         </div>
 
-        <div className="w-full lg:w-2/5">
-          <img
-            className="rounded-none lg:rounded-lg shadow-2xl hidden lg:block"
-            src={photoUrl}
-          />
-        </div>
+        {!photoShouldBeOnTheLeft && <Photo />}
       </div>
     </div>
   )

--- a/src/components/section/ProfileCardSection/ProfileCardSection.tsx
+++ b/src/components/section/ProfileCardSection/ProfileCardSection.tsx
@@ -47,7 +47,7 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
         <div className="w-full lg:w-3/5 rounded-lg lg:rounded-l-lg lg:rounded-r-none shadow-2xl bg-white opacity-75 mx-6 lg:mx-0">
           <div className="p-4 lg:p-12 text-center lg:text-left">
             <div
-              className="block lg:hidden rounded-full shadow-xl mx-auto -mt-16 h-48 w-48 bg-cover bg-center"
+              className="block lg:hidden rounded-full shadow-xl mx-auto -mt-16 h-48 w-48 bg-cover bg-top"
               style={{ backgroundImage: `url('${photoUrl}')` }}
             />
 

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -3,6 +3,10 @@ import Page from '../components/page/Page'
 import { getContentfulClient } from '../core/contentful'
 import { PageEntry, PageProps } from '../types/page'
 import { MenuSortOrderEntry, MenuSortOrderProps } from '../types/menu'
+import {
+  BannerNotificationEntry,
+  BannerNotificationProps,
+} from '../types/banner'
 
 const client = getContentfulClient()
 
@@ -16,14 +20,19 @@ const getPages = async (): Promise<PageEntry[]> => {
 }
 
 const getMenuSortOrder = async (): Promise<MenuSortOrderEntry> => {
-  const { items: menuSortOrders } = await client.getEntries<MenuSortOrderProps>(
-    {
-      content_type: 'menuSortOrder',
-      include: 1,
-    }
-  )
+  const { items: sortOrders } = await client.getEntries<MenuSortOrderProps>({
+    content_type: 'menuSortOrder',
+  })
 
-  return menuSortOrders[0]
+  return sortOrders?.[0]
+}
+
+const getBannerNotification = async (): Promise<BannerNotificationEntry> => {
+  const { items: banners } = await client.getEntries<BannerNotificationProps>({
+    content_type: 'bannerNotification',
+  })
+
+  return banners?.[0]
 }
 
 const getActivePath = (slug: null | string | string[]) => {
@@ -48,6 +57,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   const pages = await getPages()
   const menuSortOrder = await getMenuSortOrder()
+  const banner = await getBannerNotification()
   const activePath = getActivePath(slug)
 
   const sortOrder = menuSortOrder?.fields.pages.map(({ fields }) => fields.slug)
@@ -85,7 +95,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     })
 
   return page
-    ? { props: { page, menu }, revalidate: 3 }
+    ? { props: { page, menu, banner }, revalidate: 3 }
     : { redirect: { destination: '/', permanent: false } }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    body {
+        word-break: break-word;
+    }
+}

--- a/src/types/banner.d.ts
+++ b/src/types/banner.d.ts
@@ -1,0 +1,8 @@
+import { Entry } from 'contentful'
+
+interface BannerNotificationProps {
+  isEnabled: boolean
+  message: string
+}
+
+type BannerNotificationEntry = Entry<BannerNotificationProps>

--- a/src/types/section.d.ts
+++ b/src/types/section.d.ts
@@ -15,6 +15,7 @@ interface ProfileSectionProps {
   title: string
   slug: string
   photo: Entry<any>
+  photoShouldBeOnTheLeft: boolean
   vocation: string
   location: string
   getInTouchText: string


### PR DESCRIPTION
Changes:

- Created content type for BannerNotification, which is shown at the top of the page when enabled.
- ProfileSection image can now be displayed either left or right
- Profile picture positioning for mobile improved, so that it centers on the top, where the face will show up.

Fixes:

- Fix a bug where a link did not break for mobile, causing the layout to break.