### PR TITLE
Replace page references with slugs

### DIFF
--- a/src/components/animations/fade-into-view.tsx
+++ b/src/components/animations/fade-into-view.tsx
@@ -16,6 +16,7 @@ const FadeIntoView = ({ children, className, delay }: FadeIntoViewProps) => (
         from={{ opacity: 0 }}
         delay={delay}
         to={{ opacity: isVisible ? 1 : 0.1 }}
+        config={{ friction: 60 }}
       >
         {({ opacity }) => (
           <animated.div className={className} style={{ opacity }}>

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -32,3 +32,55 @@ export const omitPathRecursively = (
     })
   )
 }
+
+/**
+ * Replaces value at path inside an object recursively.
+ * A full path to the key is not required.
+ * The original object is not modified.
+ *
+ * Example:
+ *   const original = { a: { b: 'foo' } }
+ *   const replacer = (value) => value + 'bar'
+ *
+ *   replacePathsRecursively(original, 'b', replacer)
+ *   // output: { a: { b: 'foobar' } }
+ */
+export const replacePathsRecursively = (
+  original: object,
+  path: string | string[],
+  replacer: Function
+) => {
+  const paths = Array.isArray(path) ? path : [path]
+
+  let modified = original
+
+  paths.forEach((path) => {
+    modified = internal_replacePathRecursively(modified, path, replacer)
+  })
+
+  return modified
+}
+
+export const internal_replacePathRecursively = (
+  original: object,
+  path: string,
+  replacer: Function = (value, root) => undefined,
+  depth: number = 1
+) => {
+  const segments = path.split('.')
+  const final = depth === segments.length
+
+  return JSON.parse(
+    JSON.stringify(original, (key, value) => {
+      const match = key === segments[depth - 1]
+
+      if (!match) return value
+      if (!final)
+        return internal_replacePathRecursively(value, path, replacer, depth + 1)
+
+      const replacement = replacer(value)
+      if (!replacement || typeof replacement !== 'object') return replacement
+      return internal_replacePathRecursively(replacement, path, replacer)
+    })
+  )
+}


### PR DESCRIPTION
Replace page references with slugs to remove circular references and make page payloads serialisable.