### PR TITLE
feat: add treatment subpages

### DIFF
--- a/src/components/page/AppContext.tsx
+++ b/src/components/page/AppContext.tsx
@@ -1,12 +1,15 @@
-import React from 'react'
-import { MenuProps } from '../../types/menu'
+import React from 'react';
+import { MenuProps } from '../../types/menu';
+import { BannerNotificationEntry } from '../../types/banner';
 
 type ContextProps = {
-  headerMenu: MenuProps
-  footerMenu: MenuProps
-}
+  headerMenu: MenuProps;
+  footerMenu: MenuProps;
+  banner?: BannerNotificationEntry;
+};
 
 export const AppContext = React.createContext<Partial<ContextProps>>({
   headerMenu: [],
   footerMenu: [],
-})
+  banner: null,
+});

--- a/src/components/page/Banner.tsx
+++ b/src/components/page/Banner.tsx
@@ -1,10 +1,11 @@
-import { BannerNotificationEntry } from '../../types/banner';
+import { AppContext } from './AppContext';
+import { useContext } from 'react';
 
-interface Props {
-  banner?: BannerNotificationEntry;
-}
+interface Props {}
 
-const Banner = ({ banner }: Props): JSX.Element => {
+const Banner = ({}: Props): JSX.Element => {
+  const { banner } = useContext(AppContext);
+
   if (!banner || !banner.fields.isEnabled) return null;
 
   return (

--- a/src/components/page/Layout.tsx
+++ b/src/components/page/Layout.tsx
@@ -2,26 +2,20 @@ import NavBar from './navbar/NavBar';
 import Banner from './Banner';
 import { BannerNotificationEntry } from '../../types/banner';
 import Footer from './footer/Footer';
-import { AppContext } from './AppContext';
 
 interface Props {
   children: JSX.Element;
   banner?: BannerNotificationEntry;
-  pageContext?: any;
 }
 
-const Layout = ({ children, banner, pageContext }: Props): JSX.Element => {
+const Layout = ({ children }: Props): JSX.Element => {
   return (
-    <AppContext.Consumer>
-      {({ headerMenu, footerMenu }) => (
-        <div className="font-serif min-h-screen flex flex-col">
-          <Banner banner={banner} />
-          <NavBar menu={headerMenu} {...pageContext?.menu} />
-          <main>{children}</main>
-          <Footer menu={footerMenu} />
-        </div>
-      )}
-    </AppContext.Consumer>
+    <div className="font-serif min-h-screen flex flex-col">
+      <Banner />
+      <NavBar />
+      <main>{children}</main>
+      <Footer />
+    </div>
   );
 };
 

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -5,6 +5,7 @@ import Section from '../section/Section';
 import { MenuProps } from '../../types/menu';
 import { BannerNotificationEntry } from '../../types/banner';
 import { AppContext } from './AppContext';
+import { PageContext } from './PageContext';
 
 interface Props {
   page: PageEntry;
@@ -16,28 +17,32 @@ interface Props {
 const Page = ({ page, headerMenu, footerMenu, banner }: Props): JSX.Element => {
   if (!page) return <LoadingPage />;
 
-  const { sections, isHomePage, subtitle } = page.fields;
-
-  const pageContext = { menu: { isDark: isHomePage, isTransparent: isHomePage } };
+  const { sections, hasOwnHeader, hasDarkBackground, subtitle } = page.fields;
 
   return (
-    <AppContext.Provider value={{ headerMenu, footerMenu }}>
-      <Layout banner={banner} pageContext={pageContext}>
-        {page ? (
-          <>
-            {isHomePage ? null : (
-              <div className="text-center pt-6">
-                <h1 className="text-3xl">{subtitle}</h1>
-              </div>
-            )}
-            {sections?.map((section, index) => {
-              return <Section key={section.sys.id} section={section} index={index} />;
-            })}
-          </>
-        ) : (
-          <LoadingPage />
-        )}
-      </Layout>
+    <AppContext.Provider value={{ headerMenu, footerMenu, banner }}>
+      <PageContext.Provider value={{ hasOwnHeader, hasDarkBackground }}>
+        <Layout>
+          <PageContext.Consumer>
+            {({ hasOwnHeader }) =>
+              page ? (
+                <>
+                  {hasOwnHeader ? null : (
+                    <div className="text-center pt-6">
+                      <h1 className="text-xl md:text-3xl px-6 break-words">{subtitle}</h1>
+                    </div>
+                  )}
+                  {sections?.map((section, index) => {
+                    return <Section key={section.sys.id} section={section} index={index} />;
+                  })}
+                </>
+              ) : (
+                <LoadingPage />
+              )
+            }
+          </PageContext.Consumer>
+        </Layout>
+      </PageContext.Provider>
     </AppContext.Provider>
   );
 };

--- a/src/components/page/PageContext.tsx
+++ b/src/components/page/PageContext.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { PageProps } from '../../types/page';
+
+type ContextProps = Pick<PageProps, 'hasOwnHeader' | 'hasDarkBackground'>;
+
+export const PageContext = React.createContext<Partial<ContextProps>>({
+  hasOwnHeader: false,
+  hasDarkBackground: false,
+});

--- a/src/components/page/footer/CopyrightAndLinksLayer.tsx
+++ b/src/components/page/footer/CopyrightAndLinksLayer.tsx
@@ -1,11 +1,12 @@
-import { MenuProps } from '../../../types/menu';
 import MenuItems from '../../menu/MenuItems';
+import { AppContext } from '../AppContext';
+import { useContext } from 'react';
 
-interface Props {
-  menu: MenuProps;
-}
+interface Props {}
 
-const CopyrightAndLinksLayer = ({ menu }: Props): JSX.Element => {
+const CopyrightAndLinksLayer = ({}: Props): JSX.Element => {
+  const { footerMenu: menu } = useContext(AppContext);
+
   return (
     <div className="flex flex-col justify-between text-center lg:flex-row">
       <p className="order-last text-sm leading-tight text-gray-400 lg:order-first">

--- a/src/components/page/footer/Footer.tsx
+++ b/src/components/page/footer/Footer.tsx
@@ -1,17 +1,13 @@
 import CopyrightAndLinksLayer from './CopyrightAndLinksLayer';
-import LogoAndSocialLayer from './LogoAndSocialLayer';
-import { MenuProps } from '../../../types/menu';
 
-interface Props {
-  menu: MenuProps;
-}
+interface Props {}
 
-const Footer = ({ menu }: Props): JSX.Element => {
+const Footer = ({}: Props): JSX.Element => {
   return (
     <footer role="contentinfo" className="py-10 bg-black mt-auto">
       <div className="px-10 mx-auto max-w-7xl">
         {/*<LogoAndSocialLayer />*/}
-        <CopyrightAndLinksLayer menu={menu} />
+        <CopyrightAndLinksLayer />
       </div>
     </footer>
   );

--- a/src/components/page/navbar/NavBar.tsx
+++ b/src/components/page/navbar/NavBar.tsx
@@ -1,19 +1,24 @@
 import Link from 'next/link';
 import Logo from '../../../assets/logo.svg';
 import MenuItems from '../../menu/MenuItems';
-import { MenuProps } from '../../../types/menu';
 import cx from 'classnames';
+import { useContext } from 'react';
+import { PageContext } from '../PageContext';
+import { AppContext } from '../AppContext';
 
-interface Props {
-  menu: MenuProps;
-  isTransparent?: boolean;
-  isDark?: boolean;
-}
+interface Props {}
 
-const NavBar = ({ menu, isTransparent, isDark }: Props): JSX.Element => {
+const NavBar = ({}: Props): JSX.Element => {
+  const { headerMenu: menu } = useContext(AppContext);
+  const { hasDarkBackground } = useContext(PageContext);
+
   return (
     <header
-      className="hidden md:block relative w-full px-8 text-gray-300 body-font z-10"
+      className={cx(
+        'hidden md:block relative w-full px-8 text-gray-300 body-font z-10',
+        { 'bg-white bg-opacity-80': !hasDarkBackground },
+        { 'bg-black bg-opacity-50': hasDarkBackground },
+      )}
       aria-label="Main navigation bar"
     >
       <div className="container flex flex-col flex-wrap items-center justify-between py-5 mx-auto md:flex-row max-w-7xl">
@@ -28,11 +33,12 @@ const NavBar = ({ menu, isTransparent, isDark }: Props): JSX.Element => {
           ariaLabel="Main navigation"
           menu={menu}
           className={cx(
-            'top-0 left-0 z-0 flex items-center justify-center h-full py-5 -ml-0 space-x-5 text-base md:-ml-5 md:py-0',
-            { 'bg-white': !isTransparent },
+            'top-0 left-0 z-0 flex  items-center justify-center h-full py-5 -ml-0 space-x-5 text-base md:-ml-5 md:py-0',
           )}
           itemClassName={
-            isDark ? 'text-gray-200 hover:text-gray-100' : 'text-gray-900 hover:text-gray-800'
+            hasDarkBackground
+              ? 'text-gray-200 hover:text-gray-100'
+              : 'text-gray-900 hover:text-gray-800'
           }
         />
       </div>

--- a/src/components/section/ProfileCardSection/fields/Bio.tsx
+++ b/src/components/section/ProfileCardSection/fields/Bio.tsx
@@ -1,16 +1,12 @@
-import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
-import { Document } from '@contentful/rich-text-types'
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+import { Document } from '@contentful/rich-text-types';
 
 interface Props {
-  shortDescription: Document
+  shortDescription: Document;
 }
 
 const Bio = ({ shortDescription }: Props): JSX.Element => {
-  return (
-    <p className="pt-8 text-sm">
-      {documentToReactComponents(shortDescription)}
-    </p>
-  )
-}
+  return <div className="pt-8 text-sm">{documentToReactComponents(shortDescription)}</div>;
+};
 
-export default Bio
+export default Bio;

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -1,25 +1,28 @@
-import ProfileCardSection from './ProfileCardSection/ProfileCardSection'
-import { Entry } from 'contentful'
-import TherapyTypesSection from './TherapyTypesSection/TherapyTypesSection'
-import BasicSection from './BasicSection/BasicSection'
+import ProfileCardSection from './ProfileCardSection/ProfileCardSection';
+import { Entry } from 'contentful';
+import TherapyTypesSection from './TherapyTypesSection/TherapyTypesSection';
+import BasicSection from './BasicSection/BasicSection';
+import TherapyTypeDetailsSection from './TherapyTypeDetailsSection/TherapyTypeDetailsSection';
 
 interface Props {
-  section: Entry<any>
-  index?: number
+  section: Entry<any>;
+  index?: number;
 }
 const Section = ({ section, index }: Props): JSX.Element => {
-  const sectionType = section.sys.contentType.sys.id
+  const sectionType = section.sys.contentType.sys.id;
 
   switch (sectionType) {
     case 'section':
-      return <BasicSection section={section} index={index} />
+      return <BasicSection section={section} index={index} />;
     case 'profileCardSection':
-      return <ProfileCardSection section={section} />
+      return <ProfileCardSection section={section} />;
     case 'therapyTypesSection':
-      return <TherapyTypesSection section={section} />
+      return <TherapyTypesSection section={section} />;
+    case 'TherapyTypeDetailedSection':
+      return <TherapyTypeDetailsSection section={section} />;
     default:
-      return null
+      return null;
   }
-}
+};
 
-export default Section
+export default Section;

--- a/src/components/section/TherapyTypeDetailsSection/TherapyTypeDetailsSection.tsx
+++ b/src/components/section/TherapyTypeDetailsSection/TherapyTypeDetailsSection.tsx
@@ -1,0 +1,54 @@
+import { TherapyTypeDetailsEntry } from '../../../types/section';
+import FadeIntoView from '../../animations/fade-into-view';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+
+interface Props {
+  section: TherapyTypeDetailsEntry;
+}
+
+const TherapyTypeDetailsSection = ({ section }: Props): JSX.Element => {
+  const { slug, therapyTypeCard } = section.fields;
+  const { title, subtitle, image, content } = therapyTypeCard.fields;
+
+  const imageProps = {
+    src: `https:${image.fields.file.url}`,
+    width: image.fields.file.details.image.width,
+    height: image.fields.file.details.image.height,
+  };
+
+  return (
+    <section id={slug} className="w-full bg-white -mt-24">
+      <div
+        className="w-full h-screen bg-cover"
+        style={{ backgroundImage: `url(${imageProps.src}` }}
+      >
+        <div className="pt-24 h-full w-full flex flex-col items-center justify-center gap-3">
+          <div className="h-2/5" />
+
+          <FadeIntoView className="px-3">
+            <h1 className="font-bold text-4xl md:text-5xl lg:text-6xl bg-white py-3 px-3 sm:px-12 rounded text-center">
+              {title}
+            </h1>
+          </FadeIntoView>
+
+          <FadeIntoView className="px-3">
+            <p className="text-xl md:text-xl lg:text-2xl bg-white py-3 px-3 sm:px-12 rounded text-center">
+              {subtitle}
+            </p>
+          </FadeIntoView>
+        </div>
+      </div>
+      <div className="max-w-3xl md:p-6 lg:py-12 sm:text-center mx-auto">
+        <div className="w-full px-6 md:px-0">
+          <FadeIntoView>
+            <p className="prose text-base text-gray-600 lg:text-lg mx-auto">
+              {documentToReactComponents(content)}
+            </p>
+          </FadeIntoView>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TherapyTypeDetailsSection;

--- a/src/components/section/TherapyTypesSection/TherapyTypeCard.tsx
+++ b/src/components/section/TherapyTypesSection/TherapyTypeCard.tsx
@@ -1,26 +1,34 @@
-import { TherapyTypeCardEntry } from '../../../types/section'
-import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
-import FadeIntoView from '../../animations/fade-into-view'
+import { TherapyTypeCardEntry } from '../../../types/section';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+import FadeIntoView from '../../animations/fade-into-view';
+import Link from 'next/link';
+import { useMemo } from 'react';
 
 interface Props {
-  card: TherapyTypeCardEntry
+  card: TherapyTypeCardEntry;
 }
 
 export const TherapyTypeCard = ({ card }: Props): JSX.Element => {
-  const { title, slug, subtitle, content, image, pageToLinkTo } = card.fields
+  const { title, slug, subtitle, summary, image, pageToLinkTo } = card.fields;
 
-  const link = pageToLinkTo ? `/${pageToLinkTo.fields.slug}` : undefined
+  const link = useMemo(() => {
+    if (!pageToLinkTo) return '#';
+
+    return pageToLinkTo.fields.parentPage
+      ? `/${pageToLinkTo.fields.parentPage.fields.slug}/${pageToLinkTo.fields.slug}`
+      : `/${pageToLinkTo.fields.slug}`;
+  }, [pageToLinkTo]);
 
   const imageProps = {
     src: `https:${image.fields.file.url}`,
     width: image.fields.file.details.image.width,
     height: image.fields.file.details.image.height,
-  }
+  };
 
   return (
-    <div id={slug} className="max-w-3xl pb-8 mx-auto md:py-12 lg:py-16">
-      <div className="pb-8 border-b md:px-8 md:pb-12 lg:pb-16 border-gray-150 dark:border-gray-750 sm:text-center">
-        <FadeIntoView>
+    <div id={slug} className="max-w-3xl md:p-6 lg:py-12 sm:text-center mx-auto">
+      <FadeIntoView>
+        <Link href={link}>
           <a href={link} className="block mb-10">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -29,33 +37,44 @@ export const TherapyTypeCard = ({ card }: Props): JSX.Element => {
               className="object-cover object-center w-full md:rounded h-72"
             />
           </a>
-        </FadeIntoView>
+        </Link>
+      </FadeIntoView>
 
-        <div className="w-full px-6 md:px-0">
-          <FadeIntoView>
-            <h2 className="mt-4 mb-5">
-              <a
-                href={link}
-                className="text-xl font-bold leading-tight tracking-tight md:text-2xl lg:text-3xl dark:text-gray-100 prata"
-              >
+      <div className="w-full px-6 md:px-0">
+        <FadeIntoView>
+          <h2 className="mt-4 mb-5">
+            <Link href={link}>
+              <a className="text-xl font-bold leading-tight tracking-tight md:text-2xl lg:text-3xl dark:text-gray-100 prata">
                 {title}
               </a>
-            </h2>
-          </FadeIntoView>
+            </Link>
+          </h2>
+        </FadeIntoView>
 
-          <FadeIntoView>
-            <p className="mt-5 mb-6 text-xs text-gray-500 md:text-sm">
-              {subtitle}
-            </p>
-          </FadeIntoView>
+        <FadeIntoView>
+          <Link href={link}>
+            <a>
+              <p className="mt-5 mb-6 text-xs text-gray-500 md:text-sm">{subtitle}</p>
+            </a>
+          </Link>
+        </FadeIntoView>
 
-          <FadeIntoView>
-            <p className="prose text-base text-gray-600 lg:text-lg">
-              {documentToReactComponents(content)}
-            </p>
-          </FadeIntoView>
-        </div>
+        <FadeIntoView>
+          <p className="prose text-base text-gray-600 lg:text-lg mx-auto">
+            {documentToReactComponents(summary)}
+          </p>
+        </FadeIntoView>
+
+        <FadeIntoView delay={400}>
+          <div className="pt-3">
+            <Link href={link}>
+              <a className="lg:text-lg text-gray-500 hover:text-gray-700 underline">Lees meer »</a>
+            </Link>
+          </div>
+        </FadeIntoView>
       </div>
+
+      <div className="w-full border-b border-gray-150 dark:border-gray-750 pt-12" />
     </div>
-  )
-}
+  );
+};

--- a/src/components/section/TherapyTypesSection/TherapyTypesSection.tsx
+++ b/src/components/section/TherapyTypesSection/TherapyTypesSection.tsx
@@ -1,20 +1,20 @@
-import { TypesOfTherapyEntry } from '../../../types/section'
-import { TherapyTypeCard } from './TherapyTypeCard'
+import { TypesOfTherapyEntry } from '../../../types/section';
+import { TherapyTypeCard } from './TherapyTypeCard';
 
 interface Props {
-  section: TypesOfTherapyEntry
+  section: TypesOfTherapyEntry;
 }
 
 const TherapyTypesSection = ({ section }: Props): JSX.Element => {
-  const { slug, therapyTypeCards } = section.fields
+  const { slug, therapyTypeCards } = section.fields;
 
   return (
-    <section id={slug} className="w-full bg-white lg:pt-40">
+    <section id={slug} className="w-full bg-white py-6">
       {therapyTypeCards?.map((card) => (
         <TherapyTypeCard key={card.sys.id} card={card} />
       ))}
     </section>
-  )
-}
+  );
+};
 
-export default TherapyTypesSection
+export default TherapyTypesSection;

--- a/src/types/page.d.ts
+++ b/src/types/page.d.ts
@@ -1,19 +1,21 @@
 // import { Document } from '@contentful/rich-text-types'
 
-import { Entry } from 'contentful'
+import { Entry } from 'contentful';
 
 interface PageProps {
-  title: string
-  slug: string
-  menuItemTitle: string
-  subtitle: string
-  icon: string
-  isHomePage: boolean
-  parentPage: any
-  shouldBeShownInHeader: boolean
-  shouldBeShownInFooter: boolean
-  shouldBeShownInSubmenus: boolean
-  sections: any
+  title: string;
+  slug: string;
+  menuItemTitle: string;
+  subtitle: string;
+  icon: string;
+  isHomePage: boolean;
+  hasOwnHeader: boolean;
+  hasDarkBackground: boolean;
+  parentPage: any;
+  shouldBeShownInHeader: boolean;
+  shouldBeShownInFooter: boolean;
+  shouldBeShownInSubmenus: boolean;
+  sections: any;
 }
 
-type PageEntry = Entry<PageProps>
+type PageEntry = Entry<PageProps>;

--- a/src/types/section.d.ts
+++ b/src/types/section.d.ts
@@ -1,60 +1,69 @@
-import { Document } from '@contentful/rich-text-types'
-import { Entry } from 'contentful'
-import { PageEntry } from './page'
+import { Document } from '@contentful/rich-text-types';
+import { Entry } from 'contentful';
+import { PageEntry } from './page';
 
 interface BasicSectionProps {
-  title: string
-  subtitle: string
-  slug: string
-  content: Document
+  title: string;
+  subtitle: string;
+  slug: string;
+  content: Document;
 }
 
-type BasicSectionEntry = Entry<BasicSectionProps>
+type BasicSectionEntry = Entry<BasicSectionProps>;
 
 interface ProfileSectionProps {
-  title: string
-  slug: string
-  photo: Entry<any>
-  photoShouldBeOnTheLeft: boolean
-  vocation: string
-  location: string
-  getInTouchText: string
-  getInTouchLink: string
-  shortDescription: Document
-  instagramHandle: string
-  facebookHandle: string
-  twitterHandle: string
-  youtubeHandle: string
-  linkedInHandle: string
+  title: string;
+  slug: string;
+  photo: Entry<any>;
+  photoShouldBeOnTheLeft: boolean;
+  vocation: string;
+  location: string;
+  getInTouchText: string;
+  getInTouchLink: string;
+  shortDescription: Document;
+  instagramHandle: string;
+  facebookHandle: string;
+  twitterHandle: string;
+  youtubeHandle: string;
+  linkedInHandle: string;
 }
 
-type ProfileSectionEntry = Entry<ProfileSectionProps>
+type ProfileSectionEntry = Entry<ProfileSectionProps>;
 
 interface TherapyTypeCardProps {
-  image: Entry<any>
-  title: string
-  slug: string
-  subtitle: string
-  content: Document
-  pageToLinkTo?: PageEntry
+  image: Entry<any>;
+  title: string;
+  slug: string;
+  subtitle: string;
+  summary: Document;
+  content: Document;
+  pageToLinkTo?: PageEntry;
 }
 
-type TherapyTypeCardEntry = Entry<TherapyTypeCardProps>
+type TherapyTypeCardEntry = Entry<TherapyTypeCardProps>;
 
 interface TypesOfTherapyProps {
-  title: string
-  slug: string
-  therapyTypeCards: TherapyTypeCardEntry[]
-  vocation: string
-  location: string
-  getInTouchText: string
-  getInTouchLink: string
-  shortDescription: Document
-  instagramHandle: string
-  facebookHandle: string
-  twitterHandle: string
-  youtubeHandle: string
-  linkedInHandle: string
+  title: string;
+  slug: string;
+  therapyTypeCards: TherapyTypeCardEntry[];
+  vocation: string;
+  location: string;
+  getInTouchText: string;
+  getInTouchLink: string;
+  shortDescription: Document;
+  instagramHandle: string;
+  facebookHandle: string;
+  twitterHandle: string;
+  youtubeHandle: string;
+  linkedInHandle: string;
 }
 
-type TypesOfTherapyEntry = Entry<TypesOfTherapyProps>
+type TypesOfTherapyEntry = Entry<TypesOfTherapyProps>;
+
+interface TherapyTypeDetailsProps {
+  title: string;
+  slug: string;
+  therapyTypeCard: TherapyTypeCardEntry;
+}
+
+type TherapyTypeDetailsEntry = Entry<TherapyTypeDetailsProps>;

--- a/test/components/__snapshots__/Layout.test.tsx.snap
+++ b/test/components/__snapshots__/Layout.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Layout matches snapshot 1`] = `
   >
     <header
       aria-label="Main navigation bar"
-      class="hidden md:block relative w-full px-8 text-gray-300 body-font z-10"
+      class="hidden md:block relative w-full px-8 text-gray-300 body-font z-10 bg-white bg-opacity-80"
     >
       <div
         class="container flex flex-col flex-wrap items-center justify-between py-5 mx-auto md:flex-row max-w-7xl"
@@ -23,7 +23,7 @@ exports[`Layout matches snapshot 1`] = `
         </a>
         <nav
           aria-label="Main navigation"
-          class="top-0 left-0 z-0 flex items-center justify-center h-full py-5 -ml-0 space-x-5 text-base md:-ml-5 md:py-0 bg-white"
+          class="top-0 left-0 z-0 flex  items-center justify-center h-full py-5 -ml-0 space-x-5 text-base md:-ml-5 md:py-0"
           role="navigation"
         />
       </div>


### PR DESCRIPTION
Changes:

- Add light and dark menus
- Add option to hide default page heading
- Add option to set menu to dark or light per page (depending on what background is used)
- Use summary for TherapyTypes section
- Use full content for TherapyType details page.