### PR TITLE
Revamp site branding and sections

### DIFF
--- a/src/components/content/renderContent.tsx
+++ b/src/components/content/renderContent.tsx
@@ -19,6 +19,7 @@ const options: Options = {
       const isImage = contentType.startsWith('image/');
 
       return isImage ? (
+        // eslint-disable-next-line @next/next/no-img-element
         <img src={url} alt={title || description || fileName} />
       ) : (
         <a

--- a/src/components/icons/IconButton.tsx
+++ b/src/components/icons/IconButton.tsx
@@ -13,9 +13,11 @@ function IconButton({ children, onClick, dark, className, ariaLabel }: Props): J
     <button
       aria-label={ariaLabel}
       className={cx(
-        'cursor-pointer p-2 md:hidden rounded',
+        'md:hidden rounded-full border border-transparent p-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-denim',
         className,
-        dark ? 'text-white hover:text-gray-100' : 'text-gray-900 hover:text-gray-800',
+        dark
+          ? 'bg-white/10 text-white hover:bg-white/20'
+          : 'bg-brand-denim/10 text-brand-denim hover:bg-brand-denim/20',
       )}
       onClick={onClick}
     >

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -27,6 +27,11 @@ const MenuItem = ({
 
   const hasSubpages = subPages.length >= 1;
 
+  const isSidebar = type === 'sidebar';
+  const linkClassName = isSidebar
+    ? 'group flex w-full items-center justify-between rounded-2xl px-4 py-3 text-base font-semibold transition-colors duration-200'
+    : 'group relative inline-flex items-center gap-1 rounded-full px-2 py-1 text-sm font-semibold transition-colors duration-200';
+
   return (
     <Popover
       className="relative"
@@ -37,29 +42,34 @@ const MenuItem = ({
         key={path}
         href={path}
         className={cx(
-          `group inline-flex items-center relative transition duration-150 ease-out`,
+          linkClassName,
           className,
-          { 'text-gray-500': isOpen },
-          { '-mr-1': hasSubpages && type !== 'sidebar' },
+          {
+            'text-brand-denim': isActive,
+          },
+          { '-mr-1': hasSubpages && !isSidebar },
         )}
       >
-        <span className="pb-0.5">{title}</span>
-        {hasSubpages && type !== 'sidebar' && (
-          <HiChevronDown
-            className={cx('text-gray-400 group-hover:text-gray-500', {
-              'text-gray-600': isOpen,
-            })}
-            aria-hidden="true"
-          />
-        )}
-        <span className="absolute bottom-0 left-0 inline-block w-full h-0.5 overflow-hidden">
+        <span className="relative flex items-center gap-2">
+          {title}
+          {hasSubpages && !isSidebar && (
+            <HiChevronDown
+              className={cx('h-4 w-4 transition-colors duration-200', {
+                'text-brand-denim': isOpen,
+                'text-current/60 group-hover:text-current': !isOpen,
+              })}
+              aria-hidden="true"
+            />
+          )}
+        </span>
+        {!isSidebar && (
           <span
             className={cx(
-              'absolute inset-0 inline-block w-full h-1/2 transform group-hover:bg-gray-600',
-              { 'bg-gray-500': isActive || isOpen },
+              'pointer-events-none absolute inset-x-0 -bottom-1 h-0.5 origin-center scale-x-0 rounded-full bg-brand-denim transition-all duration-200 ease-out group-hover:scale-x-100',
+              { 'scale-x-100': isActive || isOpen },
             )}
           />
-        </span>
+        )}
       </Link>
 
       {hasSubpages && type === 'main' && (

--- a/src/components/menu/MenuPopover.tsx
+++ b/src/components/menu/MenuPopover.tsx
@@ -31,13 +31,17 @@ function MenuPopover({
       {/* these values assume that the menu is on the right-hand side */}
       <Popover.Panel
         unmount={false}
-        className="absolute z-10 right-0 -mr-4 pt-3 transform px-2 w-screen max-w-md sm:px-0 2xl:ml-0 2xl:left-1/2 2xl:-translate-x-1/2"
+        className="absolute right-0 z-20 mt-3 w-screen max-w-lg -translate-x-3 px-2 sm:px-0 2xl:left-1/2 2xl:-translate-x-1/2"
         aria-labelledby={`${parentTitle} submenu`}
       >
-        <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-          <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
-            <Link key={headerLink} href={headerLink} className="text-gray-600 hover:text-gray-800">
-              <strong>{headerTitle}</strong>
+        <div className="overflow-hidden rounded-3xl bg-white/90 shadow-soft ring-1 ring-brand-denim/10 backdrop-blur">
+          <div className="relative grid gap-5 px-6 py-6 sm:gap-6 sm:p-8">
+            <Link
+              key={headerLink}
+              href={headerLink}
+              className="text-sm font-semibold text-brand-denim transition hover:text-brand-midnight"
+            >
+              {headerTitle || parentTitle}
             </Link>
             {children}
           </div>

--- a/src/components/menu/MenuSubItems.tsx
+++ b/src/components/menu/MenuSubItems.tsx
@@ -14,16 +14,16 @@ function MenuSubItems({ subPages }: Props): JSX.Element {
           <Link
             key={path}
             href={path}
-            className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
+            className="group -m-3 flex items-start gap-3 rounded-2xl p-3 transition hover:bg-brand-sky/40"
           >
             <DynamicIcon
               icon={icon}
-              className="shrink-0 h-6 w-6 text-indigo-600"
+              className="h-6 w-6 shrink-0 text-brand-denim"
               aria-hidden="true"
             />
             <div className="ml-4">
-              <p className="text-base font-medium text-gray-900">{title}</p>
-              <p className="mt-1 text-sm text-gray-500">{subtitle}</p>
+              <p className="text-sm font-semibold text-neutral-800 group-hover:text-brand-midnight">{title}</p>
+              <p className="mt-1 text-sm text-neutral-500">{subtitle}</p>
             </div>
           </Link>
         );

--- a/src/components/page/banner/Banner.tsx
+++ b/src/components/page/banner/Banner.tsx
@@ -10,11 +10,14 @@ const Banner = ({}: Props): JSX.Element => {
 
   return (
     <section
-      className="relative w-full px-8 text-gray-800 bg-[#00a7d3]"
-      aria-label="Temporary information banner"
+      className="relative w-full bg-brand-denim text-white"
+      aria-label="Tijdelijke melding"
     >
-      <div className="container flex flex-col flex-wrap items-center justify-between py-5 mx-auto max-w-7xl">
-        {banner.fields.message}
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-center gap-3 px-6 py-3 text-center sm:flex-row sm:gap-6 sm:text-left">
+        <span className="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/80">
+          Update
+        </span>
+        <p className="text-sm font-medium leading-relaxed text-white/90">{banner.fields.message}</p>
       </div>
     </section>
   );

--- a/src/components/page/footer/CopyrightAndLinksLayer.tsx
+++ b/src/components/page/footer/CopyrightAndLinksLayer.tsx
@@ -1,30 +1,21 @@
-import MenuItems from '../../menu/MenuItems';
-import { AppContext } from '../context/AppContext';
-import { useContext } from 'react';
+import Link from 'next/link';
 
 interface Props {}
 
-const CopyrightAndLinksLayer = ({}: Props): JSX.Element => {
-  const { footerMenu: menu } = useContext(AppContext);
+const currentYear = new Date().getFullYear();
 
+const CopyrightAndLinksLayer = ({}: Props): JSX.Element => {
   return (
-    <div className="flex flex-col justify-between text-center lg:flex-row p-2 gap-2">
-      <div className="order-last text-sm text-gray-400 lg:order-first flex justify-center gap-4 md:gap-1 flex-col md:flex-row">
-        <hr className="md:invisible my-4 border-gray-400/40" />
-        <div>
-          <strong>Loman Psychologiepraktijk</strong>
-          <strong className="invisible md:visible"> |</strong>
-        </div>
-        <div>
-          <span>Alle rechten voorbehouden</span>
-        </div>
+    <div className="flex flex-col gap-4 border-t border-white/10 pt-8 text-sm text-white/60 md:flex-row md:items-center md:justify-between">
+      <p>© {currentYear} Loman Psychologiepraktijk. Alle rechten voorbehouden.</p>
+      <div className="flex flex-wrap items-center gap-4">
+        <Link href="/privacybeleid" className="hover:text-white">
+          Privacybeleid
+        </Link>
+        <Link href="/algemene-voorwaarden" className="hover:text-white">
+          Algemene voorwaarden
+        </Link>
       </div>
-      <MenuItems
-        menu={menu}
-        ariaLabel="Footer navigation"
-        className="flex flex-col gap-4 md:flex-row justify-center pb-0 -ml-4 -mr-4 text-sm"
-        itemClassName="text-gray-400 hover:text-gray-300"
-      />
     </div>
   );
 };

--- a/src/components/page/footer/Footer.tsx
+++ b/src/components/page/footer/Footer.tsx
@@ -1,12 +1,67 @@
 import CopyrightAndLinksLayer from './CopyrightAndLinksLayer';
+import Image from 'next/image';
+import Logo from '../../../assets/logo.svg';
+import { CONTACT_DETAILS } from '../../../core/contact';
+import MenuItems from '../../menu/MenuItems';
+import { useContext } from 'react';
+import { AppContext } from '../context/AppContext';
+import Link from 'next/link';
 
 interface Props {}
 
 const Footer = ({}: Props): JSX.Element => {
+  const { footerMenu: menu } = useContext(AppContext);
+
   return (
-    <footer role="contentinfo" className="py-10 bg-black mt-auto">
-      <div className="px-10 mx-auto max-w-7xl">
-        {/*<LogoAndSocialLayer />*/}
+    <footer role="contentinfo" className="mt-auto bg-brand-midnight text-white">
+      <div className="mx-auto flex max-w-6xl flex-col gap-16 px-6 py-16">
+        <div className="grid gap-12 md:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-4">
+            <Image src={Logo} alt="Loman Psychologiepraktijk" className="h-12 w-auto" />
+            <p className="text-sm text-white/70">
+              Persoonlijke psychologiepraktijk voor duurzame verandering en veerkracht in het hart van Utrecht.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Contact</h3>
+            <div className="space-y-2 text-sm text-white/80">
+              {CONTACT_DETAILS.phone && (
+                <a href={CONTACT_DETAILS.phone.href} className="block hover:text-white">
+                  {CONTACT_DETAILS.phone.formatted}
+                </a>
+              )}
+              <a href={CONTACT_DETAILS.email.href} className="block hover:text-white">
+                {CONTACT_DETAILS.email.address}
+              </a>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Navigatie</h3>
+            <MenuItems
+              menu={menu}
+              className="flex flex-col gap-2 text-sm"
+              itemClassName="text-white/70 hover:text-white"
+              role="navigation"
+              ariaLabel="Footer menu"
+            />
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Afspraak maken</h3>
+            <p className="text-sm text-white/70">
+              Laat een bericht achter of plan direct een kennismakingsgesprek. Ik reageer binnen twee werkdagen.
+            </p>
+            <Link
+              href="/contact"
+              className="button-primary inline-flex w-full justify-center bg-white text-brand-denim hover:bg-brand-sky"
+            >
+              Plan een kennismaking
+            </Link>
+          </div>
+        </div>
+
         <CopyrightAndLinksLayer />
       </div>
     </footer>

--- a/src/components/page/header/DesktopMenu.tsx
+++ b/src/components/page/header/DesktopMenu.tsx
@@ -17,7 +17,7 @@ function DesktopMenu({}: Props): JSX.Element {
         <Image
           src={Logo}
           alt="Loman Psychologiepraktijk"
-          className="h-12 w-auto md:h-14 select-none cursor-pointer"
+          className="h-10 w-auto select-none cursor-pointer md:h-12"
         />
       </Link>
 
@@ -26,12 +26,12 @@ function DesktopMenu({}: Props): JSX.Element {
         ariaLabel="Main navigation"
         menu={menu}
         className={cx(
-          'hidden md:flex pr-8 top-0 left-0 z-0 flex items-center justify-center h-full py-5 -ml-0 space-x-4 text-base md:-ml-5 md:py-0',
+          'hidden items-center gap-8 md:flex',
         )}
         itemClassName={
           hasDarkBackground
-            ? 'text-gray-200 hover:text-gray-100'
-            : 'text-gray-900 hover:text-gray-800'
+            ? 'text-white/70 hover:text-white'
+            : 'text-neutral-700 hover:text-brand-denim'
         }
       />
     </>

--- a/src/components/page/header/Header.tsx
+++ b/src/components/page/header/Header.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { PageContext } from '../context/PageContext';
 import MobileMenu from './MobileMenu';
 import DesktopMenu from './DesktopMenu';
@@ -7,6 +7,9 @@ import MobileMenuToggle from './MobileMenuToggle';
 import { MenuContext } from '../context/MenuContext';
 import { AppContext } from '../context/AppContext';
 import { useRouter } from 'next/router';
+import { HiOutlineMail, HiOutlinePhone } from 'react-icons/hi';
+import { CONTACT_DETAILS } from '../../../core/contact';
+import Link from 'next/link';
 
 interface Props {}
 
@@ -26,23 +29,84 @@ const Header = ({}: Props): JSX.Element => {
     return () => router.events.off('routeChangeStart', hideMenu);
   }, [hideMenu, router.events]);
 
+  const contactItems = useMemo(() => {
+    const items = [] as Array<JSX.Element>;
+
+    if (CONTACT_DETAILS.phone) {
+      items.push(
+        <a
+          key="phone"
+          href={CONTACT_DETAILS.phone.href}
+          className="flex items-center gap-2 text-sm font-medium"
+        >
+          <HiOutlinePhone className="h-4 w-4" aria-hidden />
+          <span>{CONTACT_DETAILS.phone.formatted}</span>
+        </a>,
+      );
+    }
+
+    if (CONTACT_DETAILS.email) {
+      items.push(
+        <a
+          key="email"
+          href={CONTACT_DETAILS.email.href}
+          className="flex items-center gap-2 text-sm font-medium"
+        >
+          <HiOutlineMail className="h-4 w-4" aria-hidden />
+          <span>{CONTACT_DETAILS.email.address}</span>
+        </a>,
+      );
+    }
+
+    return items;
+  }, []);
+
   return (
     <header
       className={cx(
-        'w-full text-gray-300 body-font z-10',
-        { 'bg-white/80': !hasDarkBackground },
-        { 'bg-black/50': hasDarkBackground },
+        'sticky top-0 z-30 w-full border-b backdrop-blur-md transition-colors duration-300',
+        hasDarkBackground
+          ? 'border-white/10 bg-brand-midnight/90 text-white'
+          : 'border-brand-denim/10 bg-white/85 text-neutral-800 shadow-sm',
       )}
-      aria-label="Main navigation bar"
+      aria-label="Hoofdnavigatie"
     >
       <MenuContext.Provider value={{ type: 'sidebar', show, setShow, hasDarkBackground, menu }}>
         <MobileMenu />
       </MenuContext.Provider>
 
+      {contactItems.length > 0 && (
+        <div
+          className={cx(
+            'hidden border-b px-6 py-2 text-sm sm:flex sm:items-center sm:justify-between',
+            hasDarkBackground ? 'border-white/10 text-white/80' : 'border-brand-denim/10 text-neutral-600',
+          )}
+        >
+          <span className="text-xs uppercase tracking-[0.3em] text-current/70">Neem contact op</span>
+          <div className="flex items-center gap-6 text-current">{contactItems}</div>
+        </div>
+      )}
+
       <MenuContext.Provider value={{ type: 'main', show, setShow, hasDarkBackground, menu }}>
-        <div className="container flex flex-row items-center justify-between py-4 px-6 mx-auto max-w-7xl">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
           <DesktopMenu />
-          <MobileMenuToggle />
+          <div className="flex items-center gap-3">
+            {CONTACT_DETAILS.phone && (
+              <a
+                href={CONTACT_DETAILS.phone.href}
+                className={cx('hidden text-sm font-semibold md:inline-flex', {
+                  'text-white hover:text-white': hasDarkBackground,
+                  'text-brand-denim hover:text-brand-midnight': !hasDarkBackground,
+                })}
+              >
+                Bel direct
+              </a>
+            )}
+            <Link href="/contact" className="button-primary hidden sm:inline-flex">
+              Plan een kennismaking
+            </Link>
+            <MobileMenuToggle className="md:hidden" />
+          </div>
         </div>
       </MenuContext.Provider>
     </header>

--- a/src/components/page/header/MobileMenu.tsx
+++ b/src/components/page/header/MobileMenu.tsx
@@ -7,6 +7,8 @@ import IconButton from '../../icons/IconButton';
 import MenuItems from '../../menu/MenuItems';
 import cx from 'classnames';
 import Image from 'next/image';
+import { CONTACT_DETAILS } from '../../../core/contact';
+import { HiOutlineMail, HiOutlinePhone } from 'react-icons/hi';
 
 interface Props {}
 
@@ -18,37 +20,50 @@ function MobileMenu({}: Props): JSX.Element {
       <div
         className={
           show
-            ? 'w-full h-full md:hidden absolute z-40 transform translate-x-0 '
-            : 'w-full h-full md:hidden absolute z-40 transform -translate-x-full'
+            ? 'absolute z-40 h-full w-full transform translate-x-0 md:hidden'
+            : 'absolute z-40 h-full w-full transform -translate-x-full md:hidden'
         }
       >
-        <div
-          className="bg-gray-800 opacity-50 inset-0 fixed w-full h-full"
-          onClick={() => setShow(!show)}
-        />
-        <div className="w-64 z-20 absolute left-0 z-40 top-0 bg-white shadow flex-col justify-between transition duration-150 ease-in-out h-full">
-          <div className="flex flex-col justify-between h-full">
+        <div className="fixed inset-0 h-full w-full bg-brand-midnight/60" onClick={() => setShow(!show)} />
+        <div className="absolute left-0 top-0 z-40 flex h-full w-72 flex-col overflow-hidden bg-neutral-25 shadow-soft transition duration-150 ease-in-out">
+          <div className="flex h-full flex-col">
             <div className="px-6 pt-4">
-              <div className="flex justify-between items-center">
+              <div className="flex items-center justify-between">
                 <Link href="/" className="z-10" aria-label="Logo of Loman psychologiepraktijk">
-                  <Image
-                    alt="Loman Psychologiepraktijk"
-                    src={Logo}
-                    className="h-12 w-auto md:h-14 select-none cursor-pointer"
-                  />
+                  <Image alt="Loman Psychologiepraktijk" src={Logo} className="h-10 w-auto select-none" />
                 </Link>
 
                 <IconButton ariaLabel="close sidebar menu" onClick={() => setShow(!show)}>
                   <Image src={Cross} alt="close sidebar menu" />
                 </IconButton>
               </div>
+              <div className="mt-6 space-y-3 rounded-2xl bg-white/70 p-4 text-sm font-medium text-neutral-600 shadow-sm">
+                {CONTACT_DETAILS.phone && (
+                  <a href={CONTACT_DETAILS.phone.href} className="flex items-center gap-3">
+                    <HiOutlinePhone className="h-4 w-4 text-brand-denim" />
+                    <span>{CONTACT_DETAILS.phone.formatted}</span>
+                  </a>
+                )}
+                {CONTACT_DETAILS.email && (
+                  <a href={CONTACT_DETAILS.email.href} className="flex items-center gap-3">
+                    <HiOutlineMail className="h-4 w-4 text-brand-denim" />
+                    <span>{CONTACT_DETAILS.email.address}</span>
+                  </a>
+                )}
+              </div>
 
               <MenuItems
                 menu={menu}
-                className={cx('flex-col py-5 space-y-4 text-base')}
-                itemClassName={'text-gray-900 hover:text-gray-800'}
-                subMenuClassName={'pt-4'}
+                className={cx('mt-6 flex flex-col gap-2 text-base')}
+                itemClassName={'text-neutral-700 hover:text-brand-midnight'}
+                subMenuClassName={'mt-2 space-y-2 pl-4 text-sm text-neutral-500'}
               />
+            </div>
+
+            <div className="mt-auto border-t border-brand-denim/10 bg-white/60 p-6">
+              <Link href="/contact" className="button-primary w-full justify-center">
+                Plan een kennismaking
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/page/header/MobileMenuToggle.tsx
+++ b/src/components/page/header/MobileMenuToggle.tsx
@@ -19,7 +19,7 @@ function MobileMenuToggle({ className }: Props): JSX.Element {
       onClick={() => setShow(!show)}
       dark={hasDarkBackground}
     >
-      <Image src={MenuIcon} alt="menu icon" className={cx('icon', { invert: hasDarkBackground })} />
+      <Image src={MenuIcon} alt="menu icon" className={cx('icon h-6 w-6', { invert: hasDarkBackground })} />
     </IconButton>
   );
 }

--- a/src/components/page/layout/Layout.tsx
+++ b/src/components/page/layout/Layout.tsx
@@ -10,10 +10,10 @@ interface Props {
 
 const Layout = ({ children }: Props): JSX.Element => {
   return (
-    <div className="font-serif min-h-screen flex flex-col">
+    <div className="min-h-screen bg-brand-blush/60 bg-hero-gradient flex flex-col">
       <Banner />
       <NavBar />
-      <main>{children}</main>
+      <main className="flex-1">{children}</main>
       <Footer />
     </div>
   );

--- a/src/components/section/BasicSection/BasicSection.tsx
+++ b/src/components/section/BasicSection/BasicSection.tsx
@@ -10,22 +10,33 @@ interface Props {
 const BasicSection = ({ section, index }: Props): JSX.Element => {
   const { title, slug, subtitle, content } = section.fields;
 
-  const backgroundClass = index % 2 === 0 ? 'bg-[#bfc6d6]' : 'bg-white';
+  const backgroundClass = index % 2 === 0 ? 'bg-brand-blush/70' : 'bg-white/90';
 
   return (
-    <section id={slug} className={`w-full px-4 md:px-8 py-16 md:py-24 ${backgroundClass} xl:px-0`}>
-      <div className="flex flex-col max-w-4xl mx-auto">
+    <section
+      id={slug}
+      className={`w-full px-6 py-20 md:px-10 ${backgroundClass} xl:px-0`}
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-12">
         <FadeIntoView>
-          <h2 className="text-4xl font-extrabold sm:text-5xl md:text-6xl mb-12">{title}</h2>
+          <div className="flex flex-col gap-4">
+            <span className="inline-flex w-fit items-center rounded-full bg-white/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim">
+              {subtitle || 'Inzicht'}
+            </span>
+            <h2 className="text-4xl font-semibold leading-tight sm:text-5xl md:text-6xl">{title}</h2>
+          </div>
         </FadeIntoView>
 
         <FadeIntoView>
-          <div className="flex flex-col max-w-6xl mx-auto md:flex-row">
-            <div className="w-full pr-5 md:w-3/12 xl:pr-12">
-              {subtitle && <h3 className="text-2xl font-bold">{subtitle}</h3>}
+          <div className="grid gap-10 md:grid-cols-12 md:items-start">
+            <div className="md:col-span-4">
+              {subtitle && (
+                <p className="text-lg font-semibold text-brand-denim">{subtitle}</p>
+              )}
+              <div className="mt-6 h-1 w-16 rounded-full bg-brand-denim/40" />
             </div>
 
-            <div className="prose w-full mt-5 md:mt-0 md:w-4/5 md:pl-2 text-gray-700 md:text-lg">
+            <div className="prose prose-lg max-w-none md:col-span-8 text-neutral-600">
               {renderContent(content)}
             </div>
           </div>

--- a/src/components/section/OfficeHoursSection/OfficeHoursSection.tsx
+++ b/src/components/section/OfficeHoursSection/OfficeHoursSection.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { Day, translateDay } from '../../../core/locale';
 import cx from 'classnames';
 import { enforceEnDash } from '../../../core/utils';
+import { HiOutlineClock, HiOutlineInformationCircle } from 'react-icons/hi';
 
 const txClosed = (locale: string) => {
   switch (locale) {
@@ -45,46 +46,62 @@ const OfficeHoursSection = ({ section, index }: Props): JSX.Element => {
   const row = (day: Day, hours: string) => (
     <tr
       key={day}
-      className={cx({
-        'font-bold': day === thisDay,
-        'opacity-85': day !== thisDay,
-      })}
+      className={cx(
+        'transition-colors',
+        day === thisDay
+          ? 'bg-brand-sky/60 font-semibold text-brand-denim'
+          : 'text-neutral-600 hover:bg-brand-sky/30',
+      )}
     >
-      <td className="">{translateDay(day, locale)}</td>
-      <td className="pl-5">{enforceEnDash(hours)}</td>
+      <td className="px-6 py-4 text-left text-sm uppercase tracking-wide text-neutral-500">
+        <span className="text-xs font-semibold text-neutral-400">{translateDay(day, locale)}</span>
+      </td>
+      <td className="px-6 py-4 text-right text-base font-medium text-neutral-700">
+        {enforceEnDash(hours)}
+      </td>
     </tr>
   );
 
-  const backgroundClass = index % 2 === 0 ? 'bg-[#bfc6d6]' : 'bg-white';
+  const backgroundClass = index % 2 === 0 ? 'bg-white/90' : 'bg-brand-blush/70';
   return (
-    <section id={slug} className={`w-full px-4 md:px-8 py-16 md:py-24 ${backgroundClass} xl:px-0`}>
-      <div className="flex flex-col max-w-4xl mx-auto">
+    <section
+      id={slug}
+      className={`w-full px-6 py-20 md:px-10 ${backgroundClass} xl:px-0`}
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-12">
         <FadeIntoView>
-          <h2 className="text-4xl font-extrabold sm:text-5xl md:text-6xl mb-12">{title}</h2>
+          <div className="flex flex-col gap-4">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim">
+              <HiOutlineClock className="h-4 w-4" aria-hidden /> Openingstijden
+            </span>
+            <h2 className="text-4xl font-semibold leading-tight sm:text-5xl md:text-6xl">{title}</h2>
+          </div>
         </FadeIntoView>
 
         <FadeIntoView>
-          <table className="font-sans">
-            <tbody>
-              {daysStartingWithToday.map((day) =>
-                row(day, section.fields[day.toLowerCase()] || txClosed(locale)),
-              )}
-            </tbody>
-          </table>
+          <div className="overflow-hidden rounded-3xl bg-white/85 shadow-soft ring-1 ring-brand-denim/10">
+            <table className="min-w-full divide-y divide-brand-denim/10 text-sm md:text-base">
+              <tbody className="divide-y divide-brand-denim/10">
+                {daysStartingWithToday.map((day) =>
+                  row(day, section.fields[day.toLowerCase()] || txClosed(locale)),
+                )}
+              </tbody>
+            </table>
+          </div>
         </FadeIntoView>
 
         {exceptions && (
           <FadeIntoView>
-            <div className="font-sans">
-              <h3 className="text-xl mt-6 mb-2.5 font-semibold leading-6">
-                {txExceptions(locale)}
-              </h3>
-
-              <ul className="list-disc list-inside pl-5">
-                {exceptions.map((exception) => (
-                  <li key={exception}>{exception}</li>
-                ))}
-              </ul>
+            <div className="flex gap-4 rounded-3xl bg-white/80 p-6 text-sm text-neutral-600 shadow-sm ring-1 ring-brand-denim/10">
+              <HiOutlineInformationCircle className="mt-0.5 h-5 w-5 shrink-0 text-brand-denim" aria-hidden />
+              <div>
+                <h3 className="text-base font-semibold text-brand-denim">{txExceptions(locale)}</h3>
+                <ul className="mt-3 space-y-1">
+                  {exceptions.map((exception) => (
+                    <li key={exception}>{exception}</li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </FadeIntoView>
         )}

--- a/src/components/section/ProcessTimelineSection/ProcessTimelineSection.tsx
+++ b/src/components/section/ProcessTimelineSection/ProcessTimelineSection.tsx
@@ -1,0 +1,82 @@
+import { ProcessTimelineSectionEntry } from '../../../types/section';
+import FadeIntoView from '../../animations/fade-into-view';
+import { renderContent } from '../../content/renderContent';
+import Link from 'next/link';
+
+interface Props {
+  section: ProcessTimelineSectionEntry;
+  index?: number;
+}
+
+const ProcessTimelineSection = ({ section, index = 0 }: Props): JSX.Element => {
+  const { title, slug, introduction, steps, ctaLink, ctaText } = section.fields;
+  const backgroundClass = index % 2 === 0 ? 'bg-white/95' : 'bg-brand-blush/80';
+
+  return (
+    <section id={slug} className={`w-full px-6 py-24 md:px-10 ${backgroundClass}`}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-16">
+        <FadeIntoView>
+          <div className="flex flex-col gap-4 text-center md:text-left">
+            <span className="inline-flex w-fit items-center self-center rounded-full bg-brand-sky/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim md:self-start">
+              Aanpak
+            </span>
+            <h2 className="text-4xl font-semibold leading-tight text-brand-ink sm:text-5xl">{title}</h2>
+            {introduction && (
+              <div className="prose prose-lg mx-auto max-w-3xl text-neutral-600 md:mx-0">
+                {renderContent(introduction)}
+              </div>
+            )}
+          </div>
+        </FadeIntoView>
+
+        <FadeIntoView>
+          <ol className="relative ml-2 border-l border-brand-denim/20 pl-8">
+            {steps?.map((step, idx) => {
+              const { title: stepTitle, description, duration } = step.fields;
+              return (
+                <li key={step.sys.id} className="group mb-12 last:mb-0">
+                  <span className="absolute -left-[37px] flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg font-semibold text-brand-denim shadow-soft ring-1 ring-brand-denim/15">
+                    {idx + 1}
+                  </span>
+                  <div className="flex flex-col gap-3 rounded-3xl bg-white/90 p-6 shadow-soft ring-1 ring-brand-denim/10">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <h3 className="text-xl font-semibold text-brand-ink">{stepTitle}</h3>
+                      {duration && (
+                        <span className="rounded-full bg-brand-sky/50 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-brand-denim">
+                          {duration}
+                        </span>
+                      )}
+                    </div>
+                    <div className="prose prose-base max-w-none text-neutral-600">
+                      {renderContent(description)}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </FadeIntoView>
+
+        {ctaLink && (
+          <FadeIntoView>
+            <div className="flex flex-col items-start gap-4 rounded-3xl bg-brand-denim text-white p-8 md:flex-row md:items-center md:justify-between">
+              <p className="text-lg font-semibold">{ctaText || 'Klaar om de eerste stap te zetten?'}</p>
+              {ctaLink.startsWith('/') ? (
+                <Link href={ctaLink} className="button-primary bg-white text-brand-denim hover:bg-brand-sky">
+                  Plan een gesprek
+                </Link>
+              ) : (
+                <a href={ctaLink} className="button-primary bg-white text-brand-denim hover:bg-brand-sky">
+                  Plan een gesprek
+                </a>
+              )}
+            </div>
+          </FadeIntoView>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default ProcessTimelineSection;
+

--- a/src/components/section/ProfileCardSection/ProfileCardSection.tsx
+++ b/src/components/section/ProfileCardSection/ProfileCardSection.tsx
@@ -11,6 +11,7 @@ import { ProfileSectionEntry } from '../../../types/section';
 import FadeIntoView from '../../animations/fade-into-view';
 import cx from 'classnames';
 import Image from 'next/image';
+import { CONTACT_DETAILS } from '../../../core/contact';
 
 interface Props {
   section: ProfileSectionEntry;
@@ -40,65 +41,73 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
     height: photo.fields.file.details.image.height,
   };
 
-  const Photo = () => (
-    <div className="w-full lg:w-2/5 hidden lg:block">
-      <Image className="rounded-none lg:rounded-lg shadow-2xl" alt={title} {...image} />
-    </div>
+  const imageFigure = (
+    <FadeIntoView>
+      <div className="relative mx-auto max-w-sm overflow-hidden rounded-3xl bg-white/90 p-4 shadow-soft ring-1 ring-brand-denim/10">
+        <div className="relative overflow-hidden rounded-2xl">
+          <Image
+            alt={title}
+            {...image}
+            className="h-full w-full object-cover"
+            sizes="(min-width: 1024px) 360px, (min-width: 768px) 50vw, 80vw"
+          />
+        </div>
+        <div className="absolute inset-x-6 bottom-6 rounded-2xl bg-white/80 p-4 text-sm text-brand-denim shadow-lg">
+          <p className="font-semibold">{vocation}</p>
+          <p className="text-xs font-medium text-neutral-500">{location}</p>
+        </div>
+      </div>
+    </FadeIntoView>
   );
 
   return (
-    <div
-      id={slug}
-      className="w-full h-auto lg:h-screen py-12 first:pt-36 first:-mt-24 flex items-center justify-center"
-      style={{
-        background: `linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)), url('https://images.unsplash.com/photo-1446057468532-87b7525217d6?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=3902&q=80')`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'bottom',
-      }}
-    >
-      <div className="max-w-3xl flex items-center h-auto flex-wrap mx-auto my-12 lg:my-0">
-        {photoShouldBeOnTheLeft && <Photo />}
+    <section id={slug} className="relative w-full overflow-hidden bg-gradient-to-b from-brand-blush via-white to-brand-blush/60 py-24">
+      <div className="absolute inset-x-0 -top-40 h-80 bg-brand-sky/40 blur-3xl" aria-hidden />
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-16 px-6 md:px-10 lg:flex-row">
         <div
-          className={cx('w-full lg:w-3/5 shadow-2xl bg-white opacity-75 mx-4 lg:mx-0', {
-            'rounded-lg': true,
-            'lg:rounded-l-lg': !photoShouldBeOnTheLeft,
-            'lg:rounded-r-none': !photoShouldBeOnTheLeft,
-            'lg:rounded-r-lg': photoShouldBeOnTheLeft,
-            'lg:rounded-l-none': photoShouldBeOnTheLeft,
+          className={cx('w-full lg:w-1/2', {
+            'lg:order-1': photoShouldBeOnTheLeft,
+            'lg:order-2': !photoShouldBeOnTheLeft,
           })}
         >
-          <div className="p-4 lg:p-12 text-center lg:text-left">
-            <div
-              className="block lg:hidden rounded-full shadow-xl mx-auto -mt-16 h-48 w-48 bg-cover bg-top"
-              style={{ backgroundImage: `url('${image.src}')` }}
-            />
-
-            <FadeIntoView delay={100}>
-              <h1 className="text-3xl font-bold pt-8 lg:pt-0">{title}</h1>
-              <div className="mx-auto lg:mx-0 w-4/5 pt-3 border-b-2 border-emerald-500 opacity-25" />
+          {imageFigure}
+        </div>
+        <div
+          className={cx('w-full lg:w-1/2', {
+            'lg:order-2': photoShouldBeOnTheLeft,
+            'lg:order-1': !photoShouldBeOnTheLeft,
+          })}
+        >
+          <div className="flex flex-col gap-6 text-center lg:text-left">
+            <FadeIntoView>
+              <div className="inline-flex items-center justify-center gap-2 self-center rounded-full bg-brand-sky/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim lg:self-start">
+                Persoonlijk
+              </div>
             </FadeIntoView>
-
-            <FadeIntoView delay={200}>
+            <FadeIntoView>
+              <h1 className="text-4xl font-semibold leading-tight text-brand-ink sm:text-5xl">{title}</h1>
+            </FadeIntoView>
+            <FadeIntoView>
               <Vocation vocation={vocation} />
             </FadeIntoView>
-
-            <FadeIntoView delay={250}>
+            <FadeIntoView>
               <Location location={location} />
             </FadeIntoView>
-
-            <FadeIntoView delay={300}>
+            <FadeIntoView>
               <Bio shortDescription={shortDescription} />
             </FadeIntoView>
 
-            {getInTouchLink && (
-              <FadeIntoView delay={500}>
-                <GetInTouchButton text={getInTouchText} link={getInTouchLink} />
-              </FadeIntoView>
-            )}
+            <FadeIntoView>
+              <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:justify-start">
+                {getInTouchLink && <GetInTouchButton text={getInTouchText} link={getInTouchLink} />}
+                <a href={CONTACT_DETAILS.email.href} className="button-secondary">
+                  Mail {CONTACT_DETAILS.email.address}
+                </a>
+              </div>
+            </FadeIntoView>
 
-            <FadeIntoView delay={700}>
-              <div className="mt-6 pb-16 lg:pb-0 w-4/5 lg:w-full mx-auto flex flex-wrap items-center justify-between">
-                {/* Use https://simpleicons.org/ to find the svg for your preferred product */}
+            <FadeIntoView>
+              <div className="mt-6 flex flex-wrap items-center justify-center gap-4 text-brand-denim lg:justify-start">
                 {twitterHandle && <TwitterIcon handle={twitterHandle} />}
                 {facebookHandle && <FacebookIcon handle={facebookHandle} />}
                 {instagramHandle && <InstagramIcon handle={instagramHandle} />}
@@ -108,10 +117,8 @@ const ProfileCardSection = ({ section }: Props): JSX.Element => {
             </FadeIntoView>
           </div>
         </div>
-
-        {!photoShouldBeOnTheLeft && <Photo />}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/section/ProfileCardSection/fields/Bio.tsx
+++ b/src/components/section/ProfileCardSection/fields/Bio.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const Bio = ({ shortDescription }: Props): JSX.Element => {
-  return <div className="pt-8 text-sm">{renderContent(shortDescription)}</div>;
+  return <div className="prose prose-lg max-w-none text-neutral-600">{renderContent(shortDescription)}</div>;
 };
 
 export default Bio;

--- a/src/components/section/ProfileCardSection/fields/GetInTouchButton.tsx
+++ b/src/components/section/ProfileCardSection/fields/GetInTouchButton.tsx
@@ -10,15 +10,9 @@ const GetInTouchButton = ({ link, text }: Props): JSX.Element => {
   const onClick = useAnimateToAnchorClickHandler();
 
   return (
-    <div className="pt-12 pb-8">
-      <Link
-        href={link}
-        onClick={onClick}
-        className="bg-emerald-800 hover:bg-emerald-900 text-white font-bold py-2 px-4 rounded-full"
-      >
-        {text}
-      </Link>
-    </div>
+    <Link href={link} onClick={onClick} className="button-primary">
+      {text}
+    </Link>
   );
 };
 

--- a/src/components/section/ProfileCardSection/fields/Location.tsx
+++ b/src/components/section/ProfileCardSection/fields/Location.tsx
@@ -3,18 +3,7 @@ interface Props {
 }
 
 const Location = ({ location }: Props): JSX.Element => {
-  return (
-    <p className="pt-2 text-gray-600 text-xs lg:text-sm flex items-center justify-center lg:justify-start">
-      <svg
-        className="h-4 fill-current text-emerald-800 pr-4"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-      >
-        <path d="M10 20a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm7.75-8a8.01 8.01 0 0 0 0-4h-3.82a28.81 28.81 0 0 1 0 4h3.82zm-.82 2h-3.22a14.44 14.44 0 0 1-.95 3.51A8.03 8.03 0 0 0 16.93 14zm-8.85-2h3.84a24.61 24.61 0 0 0 0-4H8.08a24.61 24.61 0 0 0 0 4zm.25 2c.41 2.4 1.13 4 1.67 4s1.26-1.6 1.67-4H8.33zm-6.08-2h3.82a28.81 28.81 0 0 1 0-4H2.25a8.01 8.01 0 0 0 0 4zm.82 2a8.03 8.03 0 0 0 4.17 3.51c-.42-.96-.74-2.16-.95-3.51H3.07zm13.86-8a8.03 8.03 0 0 0-4.17-3.51c.42.96.74 2.16.95 3.51h3.22zm-8.6 0h3.34c-.41-2.4-1.13-4-1.67-4S8.74 3.6 8.33 6zM3.07 6h3.22c.2-1.35.53-2.55.95-3.51A8.03 8.03 0 0 0 3.07 6z" />
-      </svg>
-      {location}
-    </p>
-  );
+  return <p className="text-sm font-medium text-neutral-500">{location}</p>;
 };
 
 export default Location;

--- a/src/components/section/ProfileCardSection/fields/Vocation.tsx
+++ b/src/components/section/ProfileCardSection/fields/Vocation.tsx
@@ -3,18 +3,7 @@ interface Props {
 }
 
 const Vocation = ({ vocation }: Props): JSX.Element => {
-  return (
-    <p className="pt-4 text-base font-bold flex items-center justify-center lg:justify-start">
-      <svg
-        className="h-4 fill-current text-emerald-800 pr-4"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 20 20"
-      >
-        <path d="M9 12H1v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6h-8v2H9v-2zm0-1H0V5c0-1.1.9-2 2-2h4V2a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v1h4a2 2 0 0 1 2 2v6h-9V9H9v2zm3-8V2H8v1h4z" />
-      </svg>
-      {vocation}
-    </p>
-  );
+  return <p className="text-lg font-semibold text-brand-denim">{vocation}</p>;
 };
 
 export default Vocation;

--- a/src/components/section/ProfileCardSection/social/FacebookIcon.tsx
+++ b/src/components/section/ProfileCardSection/social/FacebookIcon.tsx
@@ -10,7 +10,7 @@ const FacebookIcon = ({ handle: dirtyHandle }: Props): JSX.Element => {
     <Tooltip content={`@${handle}`}>
       <a className="link" target="_blank" rel="noreferrer" href={`https://facebook.com/${handle}`}>
         <svg
-          className="h-6 fill-current text-gray-600 hover:text-emerald-800"
+          className="h-6 w-6 fill-current text-brand-denim/70 transition hover:text-brand-denim"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/section/ProfileCardSection/social/InstagramIcon.tsx
+++ b/src/components/section/ProfileCardSection/social/InstagramIcon.tsx
@@ -15,7 +15,7 @@ const InstagramIcon = ({ handle: dirtyHandle }: Props): JSX.Element => {
         href={`https://www.instagram.com/${handle}`}
       >
         <svg
-          className="h-6 fill-current text-gray-600 hover:text-emerald-800"
+          className="h-6 w-6 fill-current text-brand-denim/70 transition hover:text-brand-denim"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/section/ProfileCardSection/social/LinkedInIcon.tsx
+++ b/src/components/section/ProfileCardSection/social/LinkedInIcon.tsx
@@ -15,7 +15,7 @@ const LinkedInIcon = ({ handle: dirtyHandle }: Props): JSX.Element => {
         href={`https://www.linkedin.com/in/${handle}`}
       >
         <svg
-          className="h-6 fill-current text-gray-600 hover:text-emerald-800"
+          className="h-6 w-6 fill-current text-brand-denim/70 transition hover:text-brand-denim"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/section/ProfileCardSection/social/TwitterIcon.tsx
+++ b/src/components/section/ProfileCardSection/social/TwitterIcon.tsx
@@ -10,7 +10,7 @@ const TwitterIcon = ({ handle: dirtyHandle }: Props): JSX.Element => {
     <Tooltip content={`@${handle}`}>
       <a className="link" target="_blank" rel="noreferrer" href={`https://twitter.com/${handle}`}>
         <svg
-          className="h-6 fill-current text-gray-600 hover:text-emerald-800"
+          className="h-6 w-6 fill-current text-brand-denim/70 transition hover:text-brand-denim"
           role="img"
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/section/ProfileCardSection/social/YoutubeIcon.tsx
+++ b/src/components/section/ProfileCardSection/social/YoutubeIcon.tsx
@@ -15,7 +15,7 @@ const YoutubeIcon = ({ handle: dirtyHandle }: Props): JSX.Element => {
         href={`https://www.youtube.com/c/${handle}`}
       >
         <svg
-          className="h-6 fill-current text-gray-600 hover:text-emerald-800"
+          className="h-6 w-6 fill-current text-brand-denim/70 transition hover:text-brand-denim"
           role="img"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -4,6 +4,8 @@ import TherapyTypesSection from './TherapyTypesSection/TherapyTypesSection';
 import BasicSection from './BasicSection/BasicSection';
 import TherapyTypeDetailsSection from './TherapyTypeDetailsSection/TherapyTypeDetailsSection';
 import OfficeHoursSection from './OfficeHoursSection/OfficeHoursSection';
+import TestimonialSection from './TestimonialSection/TestimonialSection';
+import ProcessTimelineSection from './ProcessTimelineSection/ProcessTimelineSection';
 
 interface Props {
   section: Entry<any>;
@@ -28,6 +30,10 @@ const Section = ({ section, index }: Props): JSX.Element => {
       return <TherapyTypeDetailsSection section={section} />;
     case 'officeHoursSection':
       return <OfficeHoursSection section={section} index={index} />;
+    case 'testimonialSection':
+      return <TestimonialSection section={section} index={index} />;
+    case 'processTimelineSection':
+      return <ProcessTimelineSection section={section} index={index} />;
     default:
       return null;
   }

--- a/src/components/section/TestimonialSection/TestimonialCard.tsx
+++ b/src/components/section/TestimonialSection/TestimonialCard.tsx
@@ -1,0 +1,59 @@
+import Image from 'next/image';
+import { renderContent } from '../../content/renderContent';
+import { TestimonialEntry } from '../../../types/section';
+
+interface Props {
+  testimonial: TestimonialEntry;
+}
+
+export const TestimonialCard = ({ testimonial }: Props): JSX.Element => {
+  const { quote, author, role, portrait } = testimonial.fields;
+
+  const portraitImage = portrait?.fields?.file?.url
+    ? {
+        src: `https:${portrait.fields.file.url}`,
+        width: portrait.fields.file.details.image.width,
+        height: portrait.fields.file.details.image.height,
+      }
+    : null;
+
+  return (
+    <figure className="flex h-full flex-col gap-6 rounded-3xl bg-white/90 p-8 shadow-soft ring-1 ring-brand-denim/10">
+      <div className="text-brand-denim">
+        <svg
+          className="h-6 w-6"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden
+        >
+          <path
+            d="M9.5 4C6.46243 4 4 6.46243 4 9.5C4 12.5376 6.46243 15 9.5 15H11V20C11 20.5523 11.4477 21 12 21H13C13.5523 21 14 20.5523 14 20V11C14 7.68629 11.3137 5 8 5H7C6.44772 5 6 4.55228 6 4V3C6 2.44772 6.44772 2 7 2H9.5ZM19.5 4C16.4624 4 14 6.46243 14 9.5C14 12.5376 16.4624 15 19.5 15H21V20C21 20.5523 21.4477 21 22 21H23C23.5523 21 24 20.5523 24 20V11C24 7.68629 21.3137 5 18 5H17C16.4477 5 16 4.55228 16 4V3C16 2.44772 16.4477 2 17 2H19.5Z"
+            fill="currentColor"
+            fillOpacity={0.2}
+          />
+        </svg>
+      </div>
+
+      <blockquote className="prose prose-lg max-w-none text-neutral-600">
+        {renderContent(quote)}
+      </blockquote>
+
+      <figcaption className="mt-auto flex items-center gap-4">
+        {portraitImage && (
+          <Image
+            alt={author}
+            {...portraitImage}
+            className="h-12 w-12 rounded-full object-cover"
+            sizes="48px"
+          />
+        )}
+        <div>
+          <p className="text-base font-semibold text-brand-ink">{author}</p>
+          {role && <p className="text-sm text-neutral-500">{role}</p>}
+        </div>
+      </figcaption>
+    </figure>
+  );
+};
+

--- a/src/components/section/TestimonialSection/TestimonialSection.tsx
+++ b/src/components/section/TestimonialSection/TestimonialSection.tsx
@@ -1,0 +1,47 @@
+import { TestimonialSectionEntry } from '../../../types/section';
+import FadeIntoView from '../../animations/fade-into-view';
+import { renderContent } from '../../content/renderContent';
+import { TestimonialCard } from './TestimonialCard';
+
+interface Props {
+  section: TestimonialSectionEntry;
+  index?: number;
+}
+
+const TestimonialSection = ({ section, index = 0 }: Props): JSX.Element => {
+  const { title, slug, introduction, testimonials, highlight } = section.fields;
+  const backgroundClass = index % 2 === 0 ? 'bg-brand-blush/80' : 'bg-white/95';
+
+  return (
+    <section id={slug} className={`w-full px-6 py-24 md:px-10 ${backgroundClass}`}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-16">
+        <FadeIntoView>
+          <div className="flex flex-col gap-4 text-center md:text-left">
+            {highlight && (
+              <span className="inline-flex w-fit items-center self-center rounded-full bg-brand-sky/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim md:self-start">
+                {highlight}
+              </span>
+            )}
+            <h2 className="text-4xl font-semibold leading-tight text-brand-ink sm:text-5xl">{title}</h2>
+            {introduction && (
+              <div className="prose prose-lg mx-auto max-w-3xl text-neutral-600 md:mx-0">
+                {renderContent(introduction)}
+              </div>
+            )}
+          </div>
+        </FadeIntoView>
+
+        <FadeIntoView>
+          <div className="grid gap-8 md:grid-cols-2">
+            {testimonials?.map((testimonial) => (
+              <TestimonialCard key={testimonial.sys.id} testimonial={testimonial} />
+            ))}
+          </div>
+        </FadeIntoView>
+      </div>
+    </section>
+  );
+};
+
+export default TestimonialSection;
+

--- a/src/components/section/TherapyTypesSection/TherapyTypeCard.tsx
+++ b/src/components/section/TherapyTypesSection/TherapyTypeCard.tsx
@@ -3,6 +3,8 @@ import FadeIntoView from '../../animations/fade-into-view';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { renderContent } from '../../content/renderContent';
+import Image from 'next/image';
+import cx from 'classnames';
 
 interface Props {
   card: TherapyTypeCardEntry;
@@ -23,55 +25,46 @@ export const TherapyTypeCard = ({ card }: Props): JSX.Element => {
     src: `https:${image.fields.file.url}`,
     width: image.fields.file.details.image.width,
     height: image.fields.file.details.image.height,
+    className: 'h-full w-full object-cover',
   };
 
   return (
-    <div id={slug} className="max-w-3xl md:p-6 lg:py-12 sm:text-center mx-auto">
+    <article
+      id={slug}
+      className="group flex h-full flex-col overflow-hidden rounded-3xl bg-white/90 shadow-soft ring-1 ring-brand-denim/10 transition hover:-translate-y-1 hover:shadow-xl"
+    >
       <FadeIntoView>
-        <Link href={link} className="block mb-10">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt={title}
-            {...imageProps}
-            className="object-cover object-center w-full md:rounded h-72"
-          />
+        <Link href={link} className="relative block h-52 overflow-hidden">
+          <Image {...imageProps} alt={title} sizes="(min-width: 1280px) 400px, (min-width: 768px) 50vw, 100vw" />
+          {subtitle && (
+            <span className="absolute left-4 top-4 inline-flex items-center rounded-full bg-white/85 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-brand-denim shadow-sm">
+              {subtitle}
+            </span>
+          )}
         </Link>
       </FadeIntoView>
 
-      <div className="w-full px-6 md:px-0">
+      <div className="flex flex-1 flex-col gap-6 px-6 py-8">
         <FadeIntoView>
-          <h2 className="mt-4 mb-5">
-            <Link
-              href={link}
-              className="text-xl font-bold leading-tight tracking-tight md:text-2xl lg:text-3xl dark:text-gray-100 prata"
-            >
+          <h3 className="text-2xl font-semibold text-brand-ink">
+            <Link href={link} className="transition hover:text-brand-denim">
               {title}
             </Link>
-          </h2>
+          </h3>
         </FadeIntoView>
 
         <FadeIntoView>
-          <Link href={link}>
-            <p className="mt-5 mb-6 text-xs text-gray-500 md:text-sm">{subtitle}</p>
-          </Link>
+          <div className={cx('prose prose-base max-w-none text-neutral-600')}>{renderContent(summary)}</div>
         </FadeIntoView>
 
-        <FadeIntoView>
-          <div className="prose text-base text-gray-600 lg:text-lg mx-auto">
-            {renderContent(summary)}
-          </div>
-        </FadeIntoView>
-
-        <FadeIntoView delay={400}>
-          <div className="pt-3">
-            <Link href={link} className="lg:text-lg text-gray-500 hover:text-gray-700 underline">
-              Lees meer »
+        <FadeIntoView delay={200}>
+          <div className="mt-auto">
+            <Link href={link} className="button-secondary">
+              Lees meer
             </Link>
           </div>
         </FadeIntoView>
       </div>
-
-      <div className="w-full border-b border-gray-150 dark:border-gray-750 pt-12" />
-    </div>
+    </article>
   );
 };

--- a/src/components/section/TherapyTypesSection/TherapyTypesSection.tsx
+++ b/src/components/section/TherapyTypesSection/TherapyTypesSection.tsx
@@ -1,18 +1,46 @@
 import { TypesOfTherapyEntry } from '../../../types/section';
 import { TherapyTypeCard } from './TherapyTypeCard';
+import { renderContent } from '../../content/renderContent';
 
 interface Props {
   section: TypesOfTherapyEntry;
 }
 
 const TherapyTypesSection = ({ section }: Props): JSX.Element => {
-  const { slug, therapyTypeCards } = section.fields;
+  const { slug, therapyTypeCards, title, shortDescription, getInTouchLink, getInTouchText } = section.fields;
 
   return (
-    <section id={slug} className="w-full bg-white py-6">
-      {therapyTypeCards?.map((card) => (
-        <TherapyTypeCard key={card.sys.id} card={card} />
-      ))}
+    <section id={slug} className="w-full bg-white/95 px-6 py-24 md:px-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-16">
+        <div className="grid gap-10 md:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] md:items-end">
+          <div className="space-y-6">
+            <span className="inline-flex w-fit items-center rounded-full bg-brand-sky/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-denim">
+              Aanbod
+            </span>
+            <h2 className="text-4xl font-semibold leading-tight text-brand-ink sm:text-5xl">{title}</h2>
+          </div>
+          {shortDescription && (
+            <div className="prose prose-lg max-w-none text-neutral-600">
+              {renderContent(shortDescription)}
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+          {therapyTypeCards?.map((card) => (
+            <TherapyTypeCard key={card.sys.id} card={card} />
+          ))}
+        </div>
+
+        {getInTouchLink && (
+          <div className="flex flex-col items-start gap-4 rounded-3xl bg-brand-blush/70 p-8 text-brand-ink shadow-soft md:flex-row md:items-center md:justify-between">
+            <p className="text-lg font-semibold">{getInTouchText || 'Niet zeker welke begeleiding past? Ik denk graag mee.'}</p>
+            <a href={getInTouchLink} className="button-secondary">
+              Neem contact op
+            </a>
+          </div>
+        )}
+      </div>
     </section>
   );
 };

--- a/src/core/contact.ts
+++ b/src/core/contact.ts
@@ -1,0 +1,29 @@
+const sanitizePhone = (phone?: string | null) => {
+  if (!phone) return null;
+
+  const trimmed = phone.trim();
+  if (!trimmed) return null;
+
+  const tel = trimmed.replace(/[^+\d]/g, '');
+
+  if (!tel) return null;
+
+  return {
+    formatted: trimmed,
+    href: `tel:${tel}`,
+  } as const;
+};
+
+const fallbackEmail = 'info@lomanpsychologie.nl';
+
+const contactEmail = process.env.NEXT_PUBLIC_CONTACT_EMAIL || fallbackEmail;
+const contactPhone = sanitizePhone(process.env.NEXT_PUBLIC_CONTACT_PHONE || undefined);
+
+export const CONTACT_DETAILS = {
+  email: {
+    address: contactEmail,
+    href: `mailto:${contactEmail}`,
+  },
+  phone: contactPhone,
+};
+

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Work+Sans:wght@300;400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -11,15 +13,44 @@
 }
 
 @layer base {
+  :root {
+    color-scheme: light;
+  }
+
   body {
     /* prevent layout breaks */
     word-break: break-word;
 
     /* fix layout shift when navigating */
     overflow-y: scroll;
+
+    @apply font-sans text-neutral-900 bg-neutral-25 antialiased;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-display text-brand-ink tracking-tight;
   }
 
   a {
-    @apply outline-offset-4;
+    @apply outline-offset-4 transition-colors duration-200;
+  }
+
+  ::selection {
+    @apply bg-brand-denim/20 text-brand-midnight;
+  }
+}
+
+@layer components {
+  .button-primary {
+    @apply inline-flex items-center justify-center rounded-full bg-brand-denim px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-midnight focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-denim;
+  }
+
+  .button-secondary {
+    @apply inline-flex items-center justify-center rounded-full border border-brand-denim bg-transparent px-6 py-3 text-sm font-semibold text-brand-denim transition hover:border-brand-midnight hover:text-brand-midnight focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-denim;
   }
 }

--- a/src/types/section.d.ts
+++ b/src/types/section.d.ts
@@ -82,3 +82,41 @@ interface TherapyTypeDetailsProps {
 }
 
 type TherapyTypeDetailsEntry = Entry<TherapyTypeDetailsProps>;
+
+interface TestimonialProps {
+  quote: Document;
+  author: string;
+  role?: string;
+  portrait?: Entry<any>;
+}
+
+type TestimonialEntry = Entry<TestimonialProps>;
+
+interface TestimonialSectionProps {
+  title: string;
+  slug: string;
+  introduction?: Document;
+  testimonials: TestimonialEntry[];
+  highlight?: string;
+}
+
+type TestimonialSectionEntry = Entry<TestimonialSectionProps>;
+
+interface ProcessStepProps {
+  title: string;
+  description: Document;
+  duration?: string;
+}
+
+type ProcessStepEntry = Entry<ProcessStepProps>;
+
+interface ProcessTimelineSectionProps {
+  title: string;
+  slug: string;
+  introduction?: Document;
+  steps: ProcessStepEntry[];
+  ctaText?: string;
+  ctaLink?: string;
+}
+
+type ProcessTimelineSectionEntry = Entry<ProcessTimelineSectionProps>;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,45 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   safelist: [],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          midnight: '#0b1d2a',
+          ink: '#1a2a36',
+          denim: '#274c77',
+          mist: '#e7eef6',
+          blush: '#f7f3ef',
+          sand: '#f0e6dd',
+          sky: '#dbe8f6',
+          accent: '#f9735b',
+          lime: '#5fc49b',
+        },
+        neutral: {
+          25: '#fcfcfd',
+          50: '#f9fafb',
+          100: '#f2f4f7',
+          200: '#e4e7ec',
+          300: '#d0d5dd',
+          400: '#98a2b3',
+          500: '#667085',
+          600: '#475467',
+          700: '#344054',
+          800: '#1d2939',
+          900: '#101828',
+        },
+      },
+      fontFamily: {
+        display: ['"Playfair Display"', 'serif'],
+        sans: ['"Work Sans"', 'system-ui', 'sans-serif'],
+      },
+      boxShadow: {
+        soft: '0 25px 50px -12px rgba(15, 23, 42, 0.15)',
+      },
+      backgroundImage: {
+        'hero-gradient': 'radial-gradient(circle at 0% 0%, rgba(39,76,119,0.12), rgba(247,243,239,0.9))',
+      },
+    },
+  },
   plugins: [require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
## Summary
- introduce a cohesive brand palette, typography, and reusable button styles for the entire site
- redesign the navigation, hero, and key content sections with personal storytelling, premium therapy cards, and refreshed office hours styling
- add testimonial and process timeline section types and rebuild the footer into a full contact hub

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_6908dd932ba88329a0fd91075eedd3ac